### PR TITLE
Update to runtime 3.34

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "shared-modules"]
+	path = shared-modules
+	url = https://github.com/flathub/shared-modules.git

--- a/org.zotero.Zotero.json
+++ b/org.zotero.Zotero.json
@@ -1,7 +1,7 @@
 {
   "id": "org.zotero.Zotero",
   "runtime": "org.gnome.Platform",
-  "runtime-version": "3.32",
+  "runtime-version": "3.34",
   "sdk": "org.gnome.Sdk",
   "command": "zotero",
   "rename-desktop-file": "zotero.desktop",

--- a/org.zotero.Zotero.json
+++ b/org.zotero.Zotero.json
@@ -13,7 +13,7 @@
     "--filesystem=home"
   ],
   "modules": [
-      "shared-modules/dbus-glib/dbus-glib-0.110.json",
+    "shared-modules/dbus-glib/dbus-glib-0.110.json",
     {
       "name": "zotero",
       "buildsystem": "simple",

--- a/org.zotero.Zotero.json
+++ b/org.zotero.Zotero.json
@@ -13,6 +13,7 @@
     "--filesystem=home"
   ],
   "modules": [
+      "shared-modules/dbus-glib/dbus-glib-0.110.json",
     {
       "name": "zotero",
       "buildsystem": "simple",


### PR DESCRIPTION
`dbus-glib` was [removed](https://gitlab.gnome.org/GNOME/gnome-build-meta/commit/ca2add6d29940876e7efbc9d1852a218a5a8cba4) from the SDK. Also, `libcanberra` is the only library we need from the GNOME runtime. Otherwise the base runtime could be used.