### PR TITLE
Included permissions to xdg-desktop, xdg-documents, xdg-download.

### DIFF
--- a/org.zotero.Zotero.appdata.xml
+++ b/org.zotero.Zotero.appdata.xml
@@ -13,8 +13,9 @@
     </p>
     <p>
       [NOTE] If your Zotero folder is not located in the default location (~/Zotero)
-      and is outside your home directory, please grant the permission to access
-      that folder by the flatpak-override command (usage: "flatpak override --user
+      and is outside your home directory or xdg-user-dirs (xdg-desktop, 
+      xdg-documents, xdg-download), please grant the permission to access that 
+      folder by the flatpak-override command (usage: "flatpak override --user
       --filesystem=/PATH/TO/ZOTEROFOLDER org.zotero.Zotero").
     </p>
   </description>

--- a/org.zotero.Zotero.json
+++ b/org.zotero.Zotero.json
@@ -10,7 +10,10 @@
     "--socket=x11",
     "--share=ipc",
     "--share=network",
-    "--filesystem=home"
+    "--filesystem=home",
+    "--filesystem=xdg-desktop",
+    "--filesystem=xdg-documents",
+    "--filesystem=xdg-download"
   ],
   "modules": [
     "shared-modules/dbus-glib/dbus-glib-0.110.json",


### PR DESCRIPTION
These are trivial user dirs that a lot of users put Zotero data.