### PR TITLE
Z7 Beta: Install symbolic icon to the correct directory

### DIFF
--- a/org.zotero.Zotero.yaml
+++ b/org.zotero.Zotero.yaml
@@ -41,7 +41,7 @@ modules:
       - mkdir -p /app/{bin,share}
       - cp -R . /app/share/zotero
       - install -D icons/icon128.png /app/share/icons/hicolor/128x128/apps/${FLATPAK_ID}.png
-      - install -D icons/symbolic.svg /app/share/icons/hicolor/scalable/apps/${FLATPAK_ID}.svg
+      - install -D icons/symbolic.svg /app/share/icons/hicolor/symbolic/apps/${FLATPAK_ID}.svg
       - >-
         desktop-file-install
         --dir=/app/share/applications


### PR DESCRIPTION
Currently, GNOME shell will display the symbolic icon, which looks quite out of place in the app chooser and the dash. I suppose this should fix it.