### PR TITLE
Hardened Sandbox Permission For Zotero 7 Beta

### DIFF
--- a/org.zotero.Zotero.appdata.xml
+++ b/org.zotero.Zotero.appdata.xml
@@ -11,11 +11,22 @@
       Zotero [zoh-TAIR-oh] is a free, easy-to-use tool to help you collect,
       organize, cite, and share your research sources.
     </p>
+     <p>
+      NOTE: drag and drop file/extensions might not work by default.
+      Use "install extension by file", "import file", or "import" option 
+      to install extensions or import files. 
+      In order for drag and drop to work, zotero needs permission to access the folder 
+      to drag and drop from, use [flatseal](https://flathub.org/apps/com.github.tchx84.Flatseal)
+      or "flatpak override --user --filesystem=/PATH/TO/DragAndDrop org.zotero.Zotero"
+      to add such permission.
+    </p>
     <p>
-      NOTE: If your Zotero folder is not located inside your home directory (~/)
-      and is outside your xdg-user-dirs, please grant permission to access that
+      NOTE: by default, the Zotero folders will appear in "~/.var/app/org.zotero.Zotero/".
+      If your Zotero folder is not located elsewhere,
+      please grant permission to access that
       folder by the flatpak-override command (usage:
-      "flatpak override --user --filesystem=/PATH/TO/ZOTEROFOLDER org.zotero.Zotero").
+      "flatpak override --user --filesystem=/PATH/TO/ZOTEROFOLDER org.zotero.Zotero" 
+      or use [flatseal](https://flathub.org/apps/com.github.tchx84.Flatseal)).
     </p>
     <p>
       NOTE: This wrapper is not verified by, affiliated with, or supported by the Zotero project.

--- a/org.zotero.Zotero.yaml
+++ b/org.zotero.Zotero.yaml
@@ -9,14 +9,8 @@ finish-args:
   - --socket=wayland
   - --share=ipc
   - --share=network
-  - --filesystem=home
-  - --filesystem=xdg-desktop
-  - --filesystem=xdg-documents
-  - --filesystem=xdg-download
-  - --filesystem=xdg-music
-  - --filesystem=xdg-pictures
-  - --filesystem=xdg-public-share
-  - --filesystem=xdg-videos
+  - --persist=.zotero
+  - --persist=Zotero
 cleanup:
   - /share/zotero/${FLATPAK_ID}.appdata.xml
   - /share/zotero/policies.json


### PR DESCRIPTION
Hardens sandbox permissions, implementing https://github.com/flathub/org.zotero.Zotero/issues/154:
- remove all file access permission to use portal by default.
- use persistent folder to sandbox zotero folders. 

Potiential problems:
- Breaks drag and drop, which needs DE to provide support for it:
  - gnome: https://gitlab.gnome.org/GNOME/gnome-shell/-/issues/418
  - qt (I assume impacts KDE): https://bugreports.qt.io/browse/QTBUG-91357
  - sway: https://github.com/swaywm/sway/issues/6460
- The zotero folder is now in sandbox, I don't know if people will be confused by this.
- (minor) Enable `home` access will cause zotero to use folders (`Zotero` and `.zotero`) in home instead of in the sandbox.

An alternative way to go is to enable `--filesystem=home` by default, with a guide to disable it in the app description. This alternative is implemented by #156.