### PR TITLE
Alternative Implementation for #155

### DIFF
--- a/org.zotero.Zotero.appdata.xml
+++ b/org.zotero.Zotero.appdata.xml
@@ -12,6 +12,18 @@
       organize, cite, and share your research sources.
     </p>
     <p>
+      NOTE: The user home permission is provided for compatiblity purpose.
+      Because zotero 7 supports portal file chooser, home access permission can be safely removed as follows:
+      First, move folders "~/.zotero" and "~/Zotero" to the app sandbox, typically in "~/.var/app/org.zotero.Zotero/";
+      then, remove home access premission in flatseal, KDE setting, 
+      or use command "flatpak override --user --nofilesystem=home org.zotero.Zotero"; and restart zotero.
+    </p>
+    <p>
+      The drag and drop functionality might break after rejecting the permission for home directory,
+      please use file chooser instead, or grant permission to the drag and drop location via 
+      "flatpak override --user --filesystem=/PATH/TO/DragAndDrop org.zotero.Zotero" or flatseal.
+    </p>
+    <p>
       NOTE: If your Zotero folder is not located inside your home directory (~/)
       and is outside your xdg-user-dirs, please grant permission to access that
       folder by the flatpak-override command (usage:

--- a/org.zotero.Zotero.yaml
+++ b/org.zotero.Zotero.yaml
@@ -10,13 +10,13 @@ finish-args:
   - --share=ipc
   - --share=network
   - --filesystem=home
-  - --filesystem=xdg-desktop
-  - --filesystem=xdg-documents
-  - --filesystem=xdg-download
-  - --filesystem=xdg-music
-  - --filesystem=xdg-pictures
-  - --filesystem=xdg-public-share
-  - --filesystem=xdg-videos
+  - --persist=.zotero
+  - --persist=Zotero
+  # below file permission can be removed with minimal impact on usability, 
+  # we keep these permissions to preserve the functionality of the unsandboxed version
+  # See: https://github.com/flathub/org.zotero.Zotero/issues/82
+  # and the app description for details.
+  - --filesystem=home
 cleanup:
   - /share/zotero/${FLATPAK_ID}.appdata.xml
   - /share/zotero/policies.json


### PR DESCRIPTION
**This PR does not harden any permission by default**, it only makes hardening the permission easier. The "hardened by default" approach is implemented in #155 .

By default, this PR grants zotero permission to the user home dir, which is the same as current default; thus this change do not break any functionality, including drag and drop, and makes the zotero folder in the default location (`~/.zotero` and `~/Zotero`).

Changes: 
- Added documentation about removing the home dir permission. 
- Added persistent folders so that zotero folder is automatically sandboxed once the user home permission is removed.