### PR TITLE
Fix D-Bus permissions

### DIFF
--- a/org.zotero.Zotero.yaml
+++ b/org.zotero.Zotero.yaml
@@ -12,7 +12,7 @@ finish-args:
   - --share=network
   - --socket=fallback-x11
   - --socket=wayland
-  - --talk-name=org.mozilla.zotero.*
+  - --own-name=org.mozilla.zotero.*
   # below file permission can be removed with minimal impact on usability,
   # we keep these permissions to preserve the functionality of the unsandboxed version
   # See: https://github.com/flathub/org.zotero.Zotero/issues/82


### PR DESCRIPTION
Unfortunately, #230 does not actually fix #217, because `--talk-name` is too weak of a permission. We need `--own-name` instead (which implies `--talk-name`).

Explanation:

Even for the same application, Flatpak isolates every process in a separate sandbox. Every such sandbox comes with their own [`xdg-dbus-proxy`](https://github.com/flatpak/xdg-dbus-proxy) instance, which filters messages between the actual bus and the facsimile the sandboxed program sees. Therefore, IPC over D-Bus can only be achieved if the messages are forwarded by **both** proxies.

This means that the instance of Zotero that is started first must be able to claim a *well-known name*, which happens to lie in `org.mozilla.zotero.*`. Otherwise, subsequent instances simply cannot detect the running instance on the session bus, and will fail with

> [!WARNING]
> Zotero is already running, but is not responding. To use Zotero, you must first close the existing Zotero process, restart your device, or use a different profile.

because the lock file in the data directory exists.

Finally, note that `--own-name` implies `--talk-name`, as the comments in [`flatpak-proxy.c`](https://github.com/flatpak/xdg-dbus-proxy/blob/main/flatpak-proxy.c) explain.