### PR TITLE
Disable Wayland for now

### DIFF
--- a/org.zotero.Zotero.yaml
+++ b/org.zotero.Zotero.yaml
@@ -10,8 +10,7 @@ finish-args:
   - --persist=Zotero
   - --share=ipc
   - --share=network
-  - --socket=fallback-x11
-  - --socket=wayland
+  - --socket=x11 # LibreOffice integration is broken on wayland
   - --own-name=org.mozilla.zotero.*
   # below file permission can be removed with minimal impact on usability,
   # we keep these permissions to preserve the functionality of the unsandboxed version


### PR DESCRIPTION
Fixes #227 

LibreOffice integration is broken on Wayland. I assume LibreOffice usage is high enough to justify disabling it and using x11 by default until this is fixed upstream (see bug report [here](https://github.com/flathub/org.zotero.Zotero/issues/165#issuecomment-2350963114)).