### PR TITLE
always use CALLDIR=/app/share/zotero

### DIFF
--- a/org.zotero.Zotero.yaml
+++ b/org.zotero.Zotero.yaml
@@ -54,6 +54,9 @@ modules:
         path: 256x256.png
       - type: file
         path: 512x512.png
+      - type: patch
+        path: zotero-calldir.patch
+        strip-components: 0
     build-commands:
       - mkdir -p /app/{bin,share}
       - cp -R . /app/share/zotero

--- a/zotero-calldir.patch
+++ b/zotero-calldir.patch
@@ -1,0 +1,9 @@
+--- zotero	2025-10-31 08:57:31.382625497 +0100
++++ zotero-flatpak.sh	2025-10-31 08:59:00.077944256 +0100
+@@ -16,5 +16,5 @@
+ # Use wayland backend when available
+ export MOZ_ENABLE_WAYLAND=1
+ 
+-CALLDIR="$(dirname "$(readlink -f "$0")")"
++CALLDIR="/app/share/zotero"
+ "$CALLDIR/zotero-bin" -app "$CALLDIR/app/application.ini" "$@"


### PR DESCRIPTION
We know where the app is located, so we don't need the dynamic path logic from https://github.com/zotero/zotero/blob/main/app/linux/zotero