### PR TITLE
Update zotero module

### DIFF
--- a/org.zotero.Zotero.appdata.xml
+++ b/org.zotero.Zotero.appdata.xml
@@ -38,8 +38,11 @@
   <developer_name>Corporation for Digital Scholarship</developer_name>
   <update_contact>guillaumepoiriermorency@gmail.com</update_contact>
   <releases>
-    <release version="8.0-beta.24" date="2026-01-07">
+    <release version="8.0-beta.26" date="2026-01-20">
       <description></description>
+    </release>
+    <release version="8.0-beta.24" date="2026-01-07">
+      <description/>
     </release>
     <release version="8.0-beta.23" date="2025-12-30">
       <description/>

--- a/org.zotero.Zotero.yaml
+++ b/org.zotero.Zotero.yaml
@@ -28,8 +28,8 @@ modules:
     buildsystem: simple
     sources:
       - type: archive
-        url: https://download.zotero.org/client/beta/8.0-beta.24%2Bfaf8f2510/Zotero-8.0-beta.24%2Bfaf8f2510_linux-x86_64.tar.xz
-        sha512: 456ff76a8d90de02f988274af8df8f807eb1ae8aa36bd1e8778a4c7fba00a906985cbed43647601c17defdbb6c7fb295e2d072804ed4005507a19e7cd994b12b
+        url: https://download.zotero.org/client/beta/8.0-beta.26%2Bcc95b9374/Zotero-8.0-beta.26%2Bcc95b9374_linux-x86_64.tar.xz
+        sha512: 592e58d36f75fcf4e94a976ae73bd2d24558350ea3bdcd20b924b61f5c89a561c949251d3bfe554d9eeb2f95624cc5e5dc89b9c1301816a10ec609b3e8c15eea
         only-arches:
           - x86_64
         x-checker-data:
@@ -37,8 +37,8 @@ modules:
           url: https://www.zotero.org/download/client/dl?channel=beta&platform=linux-x86_64
           pattern: https://download.zotero.org/client/beta/([0-9.]+-beta[0-9.]+)*
       - type: archive
-        url: https://download.zotero.org/client/beta/8.0-beta.24%2Bfaf8f2510/Zotero-8.0-beta.24%2Bfaf8f2510_linux-arm64.tar.xz
-        sha512: 6992ed07f248713ebe0fc9b529019004bf58dafaf00af6d904d01d5d71c60f5eb480c46aaa3dfe21bd190d4dfdb235c2348ece8b36765b3be8976f9550624ff9
+        url: https://download.zotero.org/client/beta/8.0-beta.26%2Bcc95b9374/Zotero-8.0-beta.26%2Bcc95b9374_linux-arm64.tar.xz
+        sha512: 76086ab64d93586768ce0dca5d46ece10da368b56491b090df94f0b10a9f3eb2a8e9d69006ba8e64ac67a129a1fb7a185e4e645962d17b0749adc2c6f04dcc2f
         only-arches:
           - aarch64
         x-checker-data:


### PR DESCRIPTION
zotero: Update Zotero-8.0-beta.24+faf8f2510_linux-x86_64.tar.xz to 8.0-beta.26
zotero: Update Zotero-8.0-beta.24+faf8f2510_linux-arm64.tar.xz to 8.0-beta.26